### PR TITLE
Get Into Teaching and Schools Experience Added

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -90,6 +90,51 @@ SERVICE_DOCS = [
       path_prefix: "services/teaching-vacancies",
     ),
   },
+  {
+    title: "Get Into Teaching application documentation",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Get Into Teaching",
+      repo_name: "DFE-Digital/get-into-teaching-app",
+      path_in_repo: "doc",
+      path_prefix: "services/get-into-teaching",
+    ),
+  },
+  {
+    title: "Get Into Teaching API documentation",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Get Into Teaching",
+      repo_name: "DFE-Digital/get-into-teaching-api",
+      path_in_repo: "docs",
+      path_prefix: "services/get-into-teaching",
+    ),
+  },
+  {
+    title: "Get Teacher Training Adviser documentation",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Get Into Teaching",
+      repo_name: "DFE-Digital/get-teacher-training-adviser-service",
+      path_in_repo: "docs",
+      path_prefix: "services/get-into-teaching",
+    ),
+  },
+  {
+    title: "Get Into Teaching Asset Manager",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Get Into Teaching",
+      repo_name: "DFE-Digital/GITISContent",
+      path_in_repo: "docs",
+      path_prefix: "services/get-into-teaching",
+    ),
+  },
+  {
+    title: "Get School Experience documentation",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Get School Experience",
+      repo_name: "DFE-Digital/schools-experience",
+      path_in_repo: "doc",
+      path_prefix: "services/school-experience",
+    ),
+  },
 ].freeze
 
 ignore "templates/*"

--- a/config.rb
+++ b/config.rb
@@ -135,6 +135,33 @@ SERVICE_DOCS = [
       path_prefix: "services/school-experience",
     ),
   },
+  {
+    title: "Monitoring",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Infrastructure",
+      repo_name: "DFE-Digital/cf-monitoring",
+      path_in_repo: "",
+      path_prefix: "services/cf-monitoring",
+    ),
+  },
+  {
+    title: "Github Actions",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Infrastructure",
+      repo_name: "DFE-Digital/github-actions",
+      path_in_repo: "",
+      path_prefix: "services/github-actions",
+    ),
+  },
+  {
+    title: "Infrastructure",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Infrastructure",
+      repo_name: "DFE-Digital/bat-infrastructure",
+      path_in_repo: "",
+      path_prefix: "services/bat-infrastructure",
+    ),
+  },
 ].freeze
 
 ignore "templates/*"

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -26,6 +26,10 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | Get Teacher Training Adviser | [DFE-Digital/get-teacher-training-adviser-service](https://github.com/DFE-Digital/get-teacher-training-adviser-service) | Get Into Teaching |
 | Get Into Teaching Asset Manager | [DFE-Digital/GITISContent](https://github.com/DFE-Digital/GITISContent) | Get Into Teaching |
 | Get School Experience | [DFE-Digital/schools-experience](https://github.com/DFE-Digital/schools-experience) | Get School Experience |
+| Monitoring | [DFE-Digital/cf-monitoring](https://github.com/DFE-Digital/cf-monitoring) | Teacher Services Infrastructure |
+| Github Actions | [DFE-Digital/github-actions](https://github.com/DFE-Digital/github-actions) | Teacher Services Infrastructure |
+| Infrastructure | [DFE-Digital/bat-infrastructure](https://github.com/DFE-Digital/bat-infrastructure) | Teacher Services Infrastructure |
+| Uptime | [DFE-Digital/teacher-services-upptime](https://github.com/DFE-Digital/teacher-services-upptime) | Teacher Services Infrastructure |
 
 ## Table of contents
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -21,6 +21,11 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | Register trainee teachers | [DFE-Digital/register-trainee-teachers](https://github.com/DFE-Digital/register-trainee-teachers) | Publish & Register |
 | Teacher Training API | [DFE-Digital/teacher-training-api](https://github.com/DFE-Digital/teacher-training-api) | Publish & Register |
 | Teaching vacancies | [DFE-Digital/teaching-vacancies](https://github.com/DFE-Digital/teaching-vacancies) | Teaching vacancies |
+| Get Into Teaching Application | [DFE-Digital/get-into-teaching-app](https://github.com/DFE-Digital/get-into-teaching-app) | Get Into Teaching |
+| Get Into Teaching API | [DFE-Digital/get-into-teaching-api](https://github.com/DFE-Digital/get-into-teaching-api) | Get Into Teaching |
+| Get Teacher Training Adviser | [DFE-Digital/get-teacher-training-adviser-service](https://github.com/DFE-Digital/get-teacher-training-adviser-service) | Get Into Teaching |
+| Get Into Teaching Asset Manager | [DFE-Digital/GITISContent](https://github.com/DFE-Digital/GITISContent) | Get Into Teaching |
+| Get School Experience | [DFE-Digital/schools-experience](https://github.com/DFE-Digital/schools-experience) | Get School Experience |
 
 ## Table of contents
 


### PR DESCRIPTION
## [Move Documents to GitHub pages](https://trello.com/c/0GUCpmZv/1502-move-documents-to-github-pages)

## Changes
Added URLS for the Get into Teaching and School Experience projects.

## Review Comments
The actual documentation in the subordinate repositories is currently being worked upon and may not look 100%