### PR TITLE
Update references of TRA to DQT where appropriate

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -172,12 +172,12 @@ SERVICE_DOCS = [
     ),
   },
   {
-    title: "Teacher Regulation Agency documentation",
+    title: "Database of Qualified Teachers documentation",
     pages: GitHubRepoFetcher.instance.docs(
-      service_name: "Teacher Regulation Agency",
-      repo_name: "DFE-Digital/teacher-regulation-agency",
+      service_name: "Database of Qualified Teachers",
+      repo_name: "DFE-Digital/database-of-qualified-teachers",
       path_in_repo: "docs",
-      path_prefix: "services/teacher-regulation-agency",
+      path_prefix: "services/database-of-qualified-teachers",
     ),
   },
 ].freeze

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,8 +30,8 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | Github Actions | [DFE-Digital/github-actions](https://github.com/DFE-Digital/github-actions) | Teacher Services Infrastructure |
 | Infrastructure | [DFE-Digital/bat-infrastructure](https://github.com/DFE-Digital/bat-infrastructure) | Teacher Services Infrastructure |
 | Uptime | [DFE-Digital/teacher-services-upptime](https://github.com/DFE-Digital/teacher-services-upptime) | Teacher Services Infrastructure |
-| Qualified Teachers API | [DFE-Digital/qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api) | Teaching Regulations Agency |
-| Teacher Regulation Agency | [DFE-Digital/teacher-regulation-agency](https://github.com/DFE-Digital/teacher-regulation-agency) | Teacher Regulations Agency |
+| Qualified Teachers API | [DFE-Digital/qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api) | Teaching Regulation Agency |
+| Database of Qualified Teachers | [DFE-Digital/database-of-qualified-teachers](https://github.com/DFE-Digital/database-of-qualified-teachers) | Teaching Regulation Agency |
 
 ## Table of contents
 


### PR DESCRIPTION
* Update the TRA repository name and label: the repository has been renamed, and its scope is limited to DQT, not all TRA services
* Correct typos in agency name