### PR TITLE
Add reference to Teacher Misconduct System repo

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -32,6 +32,7 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | Uptime | [DFE-Digital/teacher-services-upptime](https://github.com/DFE-Digital/teacher-services-upptime) | Teacher Services Infrastructure |
 | Qualified Teachers API | [DFE-Digital/qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api) | Teaching Regulation Agency |
 | Database of Qualified Teachers | [DFE-Digital/database-of-qualified-teachers](https://github.com/DFE-Digital/database-of-qualified-teachers) | Teaching Regulation Agency |
+| Teacher Misconduct system | [DFE-Digital/teacher-misconduct-system](https://github.com/DFE-Digital/teacher-misconduct-system) | Teaching Regulation Agency |
 
 ## Table of contents
 


### PR DESCRIPTION
# Teacher Misconduct System - Link to repo

The PR adds a reference to the TMS repo, where the TMS architecture is documented.