### PR TITLE
Document cross-TS process for incident management

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -36,6 +36,11 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 
 ## Table of contents
 
+### Operating a service
+
+- [How to categorise technical incidents](/operating-a-service/how-to-categorise-technical-incidents.html)
+- [Incident playbook](/operating-a-service/incident-playbook.html)
+
 <% pages_by_category.pages.each do |category, pages| %>
 
 ### <%= category %>

--- a/source/operating-a-service/how-to-categorise-technical-incidents.html.md
+++ b/source/operating-a-service/how-to-categorise-technical-incidents.html.md
@@ -1,0 +1,100 @@
+# How to categorise technical incidents
+
+The **incident tech lead** needs to triage and categorise the incident to decide on how to respond.
+
+Ask:
+
+* What’s the urgency and why?
+* What’s the impact on our users and services?
+* What’s the extent of the issue and what services and users are affected?
+
+Use the answers to:
+
+1. categorise the incident from the categories below
+2. direct the necessary response.
+
+The categories are fluid and incidents can increase / decrease in priority following further diagnosis or incident resolution work.
+
+## Priority 1 (P1) - High (H)
+
+### Description
+
+Highest and most serious level of incident where **two or more** of the following factors apply:
+
+* 60-100% of users affected.
+* Damage to reputation of service is likely to be high.
+* Support staff are mostly or completely unable to resolve tickets due to service being down.
+
+Examples:
+
+* Total outage of ‘Apply for teacher training’ at any time
+* Total outage of ‘Publish postgraduate teacher training courses’ during ‘peak’ time, which is July-October.
+* Primary search filter on ‘Find postgraduate teacher training courses’ going down. This includes location search and subject selection.
+
+### Stakeholder groups to inform
+
+Team:
+
+* Team
+* Service support staff
+
+Senior stakeholders:
+
+* Service Owner
+* Deputy Service Owners
+
+## Priority 2 (P2) - Medium (M)
+
+### Description
+
+Next highest level of incident where **two or more** of the following factors apply:
+
+* 20-59% of users affected.
+* Damage to reputation of service is likely to be moderate.
+* Damage caused by incident increases moderately over time.
+* Support staff are in some cases unable to resolve tickets for users.
+
+This incident level requires the full attention of the incident responders during business hours and takes priority over other non-emergency work.
+
+Examples:
+  * Total outage of ‘Publish’ during off-peak time.
+  * The bulk publishing function is down.
+
+### Stakeholder groups to inform
+
+Team:
+
+* Team
+* Service support staff
+
+Senior stakeholders:
+
+* Service Owner
+* Deputy Service Owners
+
+## Priority 3 (P3) - Low (L)
+
+Lowest level of incident where **two or more** of the following factors apply:
+
+* Less than 20% of users affected.
+* Damage to reputation of service is likely to be minimal.
+* Damage caused by incident only marginally increases over time.
+* Support staff are mostly able to resolve tickets for users and support may largely be unaffected, or moderately affected in some cases.
+
+This incident level requires the attention of incident responders as a priority over regular work during business hours. Higher priority incidents take priority over this incident level.
+
+Examples:
+
+* Some minor functionality or internal tools are broken, such as one of the secondary filters.
+* The support console is down.
+
+### Stakeholder groups to inform
+
+Team:
+
+* Team
+* Service support staff
+
+Senior stakeholders:
+
+* Deputy Service Owners

--- a/source/operating-a-service/how-to-categorise-technical-incidents.html.md
+++ b/source/operating-a-service/how-to-categorise-technical-incidents.html.md
@@ -74,6 +74,8 @@ Senior stakeholders:
 
 ## Priority 3 (P3) - Low (L)
 
+### Description
+
 Lowest level of incident where **two or more** of the following factors apply:
 
 * Less than 20% of users affected.

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -10,7 +10,7 @@ Self-organise to appoint:
     (responsible for communicating and alerts to users and stakeholders)
 2.  the **Incident tech lead**
     (responsible for technical direction and communicating to the comms lead)
-3. the **Incident support lead**, when the incident involves a public-facing service
+3. the **Incident support lead**
     (responsible for monitoring Zendesk and alerting the team to any changes in the queues and severity of experience of users).
 
 ### 2. Triage the incident (all incident leads)

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -76,7 +76,7 @@ Update stakeholders on the Slack incident channel every 60 minutes, until the in
 
 1. Update the running incident report
 2. Close the incident on using `/closeincident` command in Slack
-3. Confirm that the incident has been automatically resolved on the service status dashboard (it may take 5 mins to update)
+3. Confirm that the incident has been automatically resolved on the [service status dashboard](https://teacher-services-status.education.gov.uk/) (it may take 5 mins to update)
 
 ## Incident review
 

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -51,11 +51,9 @@ Contact your users if:
 
 Informing users about incidents is generally considered best practice, but should be decided on a case by case basis with the product and service managers.
 
-## While the incident is in progress
+## While the incident is in progress (all incident leads)
 
 Keep all conversations and status updates about the incident on the dedicated Slack incident channel.
-
-[A call for further information can be requested on the thread.] - what does this mean?
 
 Use these incident stages in your Slack updates:
 
@@ -63,6 +61,12 @@ Use these incident stages in your Slack updates:
 - Incident is being assessed
 - Incident is being fixed
 - Incident is resolved
+
+Use the Slack IncidentBot `/update` command to update:
+
+- Description
+- Priority
+- Leads
 
 ### Provide regular updates every 60 minutes (comms lead)
 

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -1,0 +1,87 @@
+# Incident playbook
+
+## Once an incident happens
+
+### 1. Form an incident response team
+
+Self-organise to appoint:
+
+1.  the **Incident comms lead**
+    (responsible for communicating and alerts to users and stakeholders)
+2.  the **Incident tech lead**
+    (responsible for technical direction and communicating to the comms lead)
+3. the **Incident support lead**, when the incident involves a public-facing service
+    (responsible for monitoring Zendesk and alerting the team to any changes in the queues and severity of experience of users).
+
+### 2. Triage the incident (all incident leads)
+
+The incident leads should [triage the incident](/operating-a-service/how-to-categorise-technical-incidents.html) (P1, P2, P3).
+
+### 3. Create an incident Slack channel and inform the stakeholders (comms lead)
+
+1. Initiate the Slack IncidentBot by typing `/incident` in the message box on #twd_git_bat channel or the #tra_digital channel (as appropriate), and hit Enter.
+2. Complete the details in the IncidentBot template, and press Enter, which will automatically create a dedicated slack channel for the incident.
+3. Determine who needs to be contacted, based on the incident priority and affected services, using [the incident contact lists](https://docs.google.com/document/d/1E3sL-Om_NPHWHdYdLykVuiWux_6AmR5pn5KjIkQYHaI/edit#bookmark=id.djbosiwhbjjy).
+4. @tag the appropriate people (from the tables linked below) in the dedicated channel:
+
+### 4. Provide a service update to users outside DfE (comms lead)
+
+The Teacher Services team maintains a publicly available [service status dashboard](https://teacher-services-status.education.gov.uk/). During an incident, the comms lead needs to explain what’s happening to users outside DfE. The comms lead will need a GitHub account to do this, or delegate updates to a colleague who has one.
+
+The updates are managed via GitHub Actions and issues on the [teacher-services-upptime repository on GitHub](https://github.com/DFE-Digital/teacher-services-upptime). If a service’s automatic health check is failing continuously, an issue will be created within 5 minutes of the failure occurring and the dashboard will start reporting a service issue.
+
+To update the dashboard:
+
+1. Navigate to the appropriate incident issue on the [GitHub issues page](https://github.com/DFE-Digital/teacher-services-upptime/issues)
+2. Add a comment to the issue
+
+### 5. Start the incident report (any incident lead)
+
+Create the incident report using the template in Google Drive:
+
+- Create a running [Incident Report using this template](https://docs.google.com/document/d/1HwKCPafnluOIhIAWbSD91zxt7w3q4FGDIVKS3d_SDFA/edit?usp=sharing)
+- Rename the created file to include today’s date and save as a new file in the [Incident reports folder](https://drive.google.com/drive/folders/12uWIF4beypUpEjejTRcKtV2PFadT5met)
+
+### 6. Decide whether to contact users about an incident (support lead)
+
+Contact your users if:
+
+* The incident will negatively impact them for a prolonged period of time
+* It can pre-empt a high volume of support tickets
+
+Informing users about incidents is generally considered best practice, but should be decided on a case by case basis with the product and service managers.
+
+## While the incident is in progress
+
+Keep all conversations and status updates about the incident on the dedicated Slack incident channel.
+
+[A call for further information can be requested on the thread.] - what does this mean?
+
+Use these incident stages in your Slack updates:
+
+- Incident has occurred
+- Incident is being assessed
+- Incident is being fixed
+- Incident is resolved
+
+### Provide regular updates every 60 minutes (comms lead)
+
+Update stakeholders on the Slack incident channel every 60 minutes, until the incident has been resolved. Ensure they receive the alert even if their Slack alert notifications are turned off, and check in with them face-to-face (once back in the office).
+
+## Once the incident is resolved
+
+1. Update the running incident report
+2. Close the incident on using `/closeincident` command in Slack
+3. Confirm that the incident has been automatically resolved on the service status dashboard (it may take 5 mins to update)
+
+## Incident review
+
+1. Run an incident review meeting and cover the WHAT?
+  1. Write up an incident review with recommendations.
+  2. The report introduction should be written in plain English, avoiding technical jargon whenever possible.
+2. Publish the incident review to the [incident reports folder in Google Drive](https://drive.google.com/drive/folders/12uWIF4beypUpEjejTRcKtV2PFadT5met).
+3. Report on the incident as part of the A3 report to the Teacher Services Board.
+
+## Related links
+
+[GIT/BAT incident alerting and service support during holiday periods](https://docs.google.com/document/d/1Jo6lgN1_V3iCLE-sc950pgZ6RE1YuqU6uP3m7Smw15U/edit)

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -80,7 +80,7 @@ Update stakeholders on the Slack incident channel every 60 minutes, until the in
 
 ## Incident review
 
-1. Run an incident review meeting and cover the WHAT?
+1. Hold an incident and lesson learned review following a [blameless post mortem culture](https://codeascraft.com/2012/05/22/blameless-postmortems/) so your service can improve.
   1. Write up an incident review with recommendations.
   2. The report introduction should be written in plain English, avoiding technical jargon whenever possible.
 2. Publish the incident review to the [incident reports folder in Google Drive](https://drive.google.com/drive/folders/12uWIF4beypUpEjejTRcKtV2PFadT5met).

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -22,7 +22,7 @@ The incident leads should [triage the incident](/operating-a-service/how-to-cate
 1. Initiate the Slack IncidentBot by typing `/incident` in the message box on #twd_git_bat channel or the #tra_digital channel (as appropriate), and hit Enter.
 2. Complete the details in the IncidentBot template, and press Enter, which will automatically create a dedicated slack channel for the incident.
 3. Determine who needs to be contacted, based on the incident priority and affected services, using [the incident contact lists](https://docs.google.com/document/d/1E3sL-Om_NPHWHdYdLykVuiWux_6AmR5pn5KjIkQYHaI/edit#bookmark=id.djbosiwhbjjy).
-4. @tag the appropriate people (from the tables linked below) in the dedicated channel:
+4.  Invite the appropriate people from the contact lists to the incident channel.
 
 ### 4. Provide a service update to users outside DfE (comms lead)
 

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -20,7 +20,7 @@ The incident leads should [triage the incident](/operating-a-service/how-to-cate
 ### 3. Create an incident Slack channel and inform the stakeholders (comms lead)
 
 1. Initiate the Slack IncidentBot by typing `/incident` in the message box on #twd_git_bat channel or the #tra_digital channel (as appropriate), and hit Enter.
-2. Complete the details in the IncidentBot template, and press Enter, which will automatically create a dedicated slack channel for the incident.
+2. Complete the details in the IncidentBot template, and press Enter, which will automatically create a dedicated Slack channel for the incident.
 3. Determine who needs to be contacted, based on the incident priority and affected services, using [the incident contact lists](https://docs.google.com/document/d/1E3sL-Om_NPHWHdYdLykVuiWux_6AmR5pn5KjIkQYHaI/edit#bookmark=id.djbosiwhbjjy).
 4.  Invite the appropriate people from the contact lists to the incident channel.
 


### PR DESCRIPTION
## Context

The technical incident management process is similar enough across the various Teacher Services programmes (GIT, BAT, TRA, CPD) to warrant an attempt for a unified one.

This PR proposes the v1 of what the common process could look like.

## Screenshots

**The index page**
<img width="750" alt="image" src="https://user-images.githubusercontent.com/23801/155981531-ec636121-4c6e-454b-9bc3-c3e69ef9c54d.png">

**The incident playbook**
![screencapture-192-168-1-151-4567-operating-a-service-incident-playbook-html-2022-02-28-14_27_43](https://user-images.githubusercontent.com/23801/156000829-8616d310-5493-4572-8f20-745aed3cfc06.png)

**How to categorise technical incidents** 
![screencapture-192-168-1-151-4567-operating-a-service-how-to-categorise-technical-incidents-html-2022-02-28-14_32_20](https://user-images.githubusercontent.com/23801/156000872-cdf8cd5d-9e9b-4ac3-9bcf-2dd9ce135ad7.png)

