### PR TITLE
Add 'Find a lost TRN' to the documentation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -181,6 +181,24 @@ SERVICE_DOCS = [
     ),
   },
   {
+    title: "Find a lost TRN documentation",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Find a lost TRN",
+      repo_name: "DFE-Digital/find-a-lost-trn",
+      path_in_repo: "docs",
+      path_prefix: "services/find-a-lost-trn",
+    ),
+  },
+  {
+    title: "Find a lost TRN decisions",
+    pages: GitHubRepoFetcher.instance.docs(
+      service_name: "Find a lost TRN",
+      repo_name: "DFE-Digital/find-a-lost-trn",
+      path_in_repo: "adr",
+      path_prefix: "services/find-a-lost-trn",
+    ),
+  },
+  {
     title: "Teacher Misconduct System documentation",
     pages: GitHubRepoFetcher.instance.docs(
       service_name: "Teacher Misconduct System",

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -30,8 +30,9 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | Github Actions | [DFE-Digital/github-actions](https://github.com/DFE-Digital/github-actions) | Teacher Services Infrastructure |
 | Infrastructure | [DFE-Digital/bat-infrastructure](https://github.com/DFE-Digital/bat-infrastructure) | Teacher Services Infrastructure |
 | Uptime | [DFE-Digital/teacher-services-upptime](https://github.com/DFE-Digital/teacher-services-upptime) | Teacher Services Infrastructure |
-| Qualified Teachers API | [DFE-Digital/qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api) | Teaching Regulation Agency |
 | Database of Qualified Teachers | [DFE-Digital/database-of-qualified-teachers](https://github.com/DFE-Digital/database-of-qualified-teachers) | Teaching Regulation Agency |
+| Find a lost TRN | [DFE-Digital/find-a-lost-trn](https://github.com/DFE-Digital/find-a-lost-trn) | Teaching Regulation Agency |
+| Qualified Teachers API | [DFE-Digital/qualified-teachers-api](https://github.com/DFE-Digital/qualified-teachers-api) | Teaching Regulation Agency |
 | Teacher Misconduct System | [DFE-Digital/teacher-misconduct-system](https://github.com/DFE-Digital/teacher-misconduct-system) | Teaching Regulation Agency |
 
 ## Table of contents


### PR DESCRIPTION
1. Add the repository to the list of TS repos
2. Ensure the ADRs and ops manual are pulled in

<img width="627" alt="image" src="https://user-images.githubusercontent.com/23801/159329664-feddd61a-b2dc-4371-ba73-bd6363c105e4.png">
