### PR TITLE
`teacher-training-api` renamed to `publish-teacher-training`

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -6,7 +6,7 @@ GovukTechDocs.configure(self)
 
 SERVICE_DOCS = [
   {
-    title: "Teacher Training API documentation",
+    title: "Publish teacher training courses API",
     pages: GitHubRepoFetcher.instance.docs(
       service_name: "Teacher Training API",
       repo_name: "DFE-Digital/publish-teacher-training",
@@ -16,7 +16,7 @@ SERVICE_DOCS = [
     ),
   },
   {
-    title: "Teacher Training API decisions",
+    title: "Publish teacher training courses decisions",
     pages: GitHubRepoFetcher.instance.docs(
       service_name: "Teacher Training API",
       repo_name: "DFE-Digital/publish-teacher-training",

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -19,7 +19,7 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | GOV.UK Markdown | [DFE-Digital/govuk_markdown](https://github.com/DFE-Digital/govuk_markdown) | Candidate & Provendor |
 | Publish teacher training | [DFE-Digital/publish-teacher-training](https://github.com/DFE-Digital/publish-teacher-training) | Publish & Register |
 | Register trainee teachers | [DFE-Digital/register-trainee-teachers](https://github.com/DFE-Digital/register-trainee-teachers) | Publish & Register |
-| Publish Teacher Training API | [DFE-Digital/publish-teacher-training](https://github.com/DFE-Digital/publish-teacher-training) | Publish & Register |
+| Publish teacher training courses | [DFE-Digital/publish-teacher-training](https://github.com/DFE-Digital/publish-teacher-training) | Publish & Register |
 | Teaching vacancies | [DFE-Digital/teaching-vacancies](https://github.com/DFE-Digital/teaching-vacancies) | Teaching vacancies |
 | Get Into Teaching Application | [DFE-Digital/get-into-teaching-app](https://github.com/DFE-Digital/get-into-teaching-app) | Get Into Teaching |
 | Get Into Teaching API | [DFE-Digital/get-into-teaching-api](https://github.com/DFE-Digital/get-into-teaching-api) | Get Into Teaching |


### PR DESCRIPTION
As well as bringing the documentation up to date, this change will hopefully also fix the current build issues with `master` in this repo, meaning that changes aren't getting deployed...

I still can't test this locally due to annoying C compiler errors, so... I hope it's OK. Perhaps you might get a chance to run it locally? :pray: 

FYI, a local `bundle install` fails with this:

```
conftest.c: At top level:
conftest.c:3:10: fatal error: zlib.h: No such file or directory
    3 | #include <zlib.h>
      |          ^~~~~~~~
```

I have zlib, but I'm on NixOS so it's installed in `/nix/store/ajcfjdfhxqcb035lbhp99fg3nizp4d57-zlib-1.2.11` and I cannot for the life of me work out how to make `bundler` understand this fact.

And doing it the "[NixOS way](https://github.com/nix-community/bundix)" results in this lovely error:

```
xml_document.c: At top level:
xml_document.c:495:14: error: conflicting types for 'canonicalize'
  495 | static VALUE canonicalize(int argc, VALUE* argv, VALUE self)
      |              ^~~~~~~~~~~~
In file included from /nix/store/mp3alrlqwfv0bkgl97rz0wrchnwjk44l-glibc-2.33-62-dev/include/features.h:473,
                 from /nix/store/mp3alrlqwfv0bkgl97rz0wrchnwjk44l-glibc-2.33-62-dev/include/bits/libc-header-start.h:33,
                 from /nix/store/mp3alrlqwfv0bkgl97rz0wrchnwjk44l-glibc-2.33-62-dev/include/stdlib.h:25,
                 from ./nokogiri.h:4,
                 from ./xml_document.h:4,
                 from xml_document.c:1:
/nix/store/mp3alrlqwfv0bkgl97rz0wrchnwjk44l-glibc-2.33-62-dev/include/bits/mathcalls.h:374:1: note: previous declaration of 'canonicalize' was here
  374 | __MATHDECL_1 (int, canonicalize,, (_Mdouble_ *__cx, const _Mdouble_ *__x));
      | ^~~~~~~~~~~~
In file included from /nix/store/iq61x2rmvs472fxsgfz15i231di1jya1-ruby-2.7.5/include/ruby-2.7.0/ruby.h:33,
                 from ./nokogiri.h:33,
                 from ./xml_document.h:4,
                 from xml_document.c:1:
```

Nice. Real nice. A naming conflict between the code it's compiling and something inside `glibc`. I balk at the thought of convincing it to do whatever it's trying to do from locally modified sources (so I could rename this `canonicalize` function to something else; it's declared `static` so that should be fairly trivial to resolve). I hate package managers.