### PR TITLE
Display dependency information

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+GITHUB_TOKEN=test-token

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rake"
 # Include the tech docs gem
 gem "govuk_tech_docs"
 
+gem "dotenv"
 gem "faraday-http-cache"
 gem "faraday_middleware"
 gem "html-pipeline"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
+  dotenv
   faraday-http-cache
   faraday_middleware
   govuk_tech_docs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This is the repo for the [Teacher Services tech docs](https://teacher-services-t
 
 ## Developing on this project
 
+Copy `.env.example` to `.env` and populate a GitHub token with read access to repos.
+
 To preview your new website locally, navigate to your project folder and run:
 
 ```sh

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require "govuk_tech_docs"
 require "rspec/core/rake_task"
-require_relative "./lib/teacher_services_tech_docs"
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/config.rb
+++ b/config.rb
@@ -2,9 +2,9 @@ require_relative "lib/teacher_services_tech_docs"
 
 GovukTechDocs.configure(self)
 
-services = YAML.load_file("config/services.yml")
+service_list = YAML.load_file("config/services.yml")
 
-services = services.reduce([]) do |list, service|
+services = service_list.reduce([]) do |list, service|
   repo = TeacherServicesTechDocs::GitHub::Repo.new(
     repo_name: service["repo_name"],
     service_name: service["name"],
@@ -20,9 +20,22 @@ end
 
 ignore "templates/*"
 
+SERVICE_PROFILES = service_list.map do |service|
+  repo = TeacherServicesTechDocs::GitHub::Repo.new(
+    repo_name: service["repo_name"],
+    service_name: service["name"],
+  )
+
+  repo.profile
+end
+
 helpers do
   def pages_by_category
     TeacherServicesTechDocs::PagesByCategory.new(sitemap)
+  end
+
+  def service_profiles
+    SERVICE_PROFILES.compact
   end
 end
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -79,3 +79,18 @@
   repo_name: "DFE-Digital/teacher-misconduct-system"
   docsets:
     - path: "docs"
+- name: "Claim additional payments for teaching"
+  repo_name: "DFE-Digital/claim-additional-payments-for-teaching"
+  docsets:
+    - path: "docs"
+- name: "Early careers framework"
+  repo_name: "DFE-Digital/early-careers-framework"
+  docsets:
+    - path: "documentation"
+- name: "ECF engage and learn"
+  repo_name: "DFE-Digital/ecf-engage-and-learn"
+  docsets:
+    - path: "documentation"
+- name: "National Professional Qualification registration"
+  repo_name: "DFE-Digital/npq-registration"
+  docsets: []

--- a/lib/teacher_services_tech_docs.rb
+++ b/lib/teacher_services_tech_docs.rb
@@ -1,6 +1,14 @@
 $LOAD_PATH.unshift "./lib"
 
 # deps
+require "dotenv"
+
+if ENV["TECH_DOCS_BUILD_ENV"] == "test"
+  Dotenv.load(".env.test")
+else
+  Dotenv.load(".env")
+end
+
 require "govuk_tech_docs"
 require "yaml"
 require "pry"
@@ -18,4 +26,5 @@ require "teacher_services_tech_docs/github/repo"
 require "teacher_services_tech_docs/github/markdown_file"
 
 module TeacherServicesTechDocs
+  GITHUB_TOKEN = ENV.fetch("GITHUB_TOKEN")
 end

--- a/lib/teacher_services_tech_docs.rb
+++ b/lib/teacher_services_tech_docs.rb
@@ -22,8 +22,11 @@ require "uri"
 require "teacher_services_tech_docs/pages_by_category"
 
 # business
+require "teacher_services_tech_docs/github/client"
 require "teacher_services_tech_docs/github/repo"
+require "teacher_services_tech_docs/github/file"
 require "teacher_services_tech_docs/github/markdown_file"
+require "teacher_services_tech_docs/github/dependencies"
 
 module TeacherServicesTechDocs
   GITHUB_TOKEN = ENV.fetch("GITHUB_TOKEN")

--- a/lib/teacher_services_tech_docs/github/client.rb
+++ b/lib/teacher_services_tech_docs/github/client.rb
@@ -1,0 +1,44 @@
+module TeacherServicesTechDocs
+  module GitHub
+    class Client
+      def get_file(repo, path)
+        file_resource = client.contents(repo, path:)
+        GitHub::File.new(file_resource)
+      rescue Octokit::NotFound
+        nil
+      end
+
+      def get_directory(repo, path)
+        client.contents(repo, path:)
+      rescue Octokit::NotFound
+        []
+      end
+
+      def get_repo(repo)
+        client.repo(repo)
+      end
+
+    private
+
+      def client
+        @client ||= begin
+          cache = ActiveSupport::Cache::FileStore.new(".cache", expires_in: 12.hours)
+
+          stack = Faraday::RackBuilder.new do |builder|
+            builder.response :logger, nil, { headers: false, bodies: false }
+            builder.use FaradayMiddleware::Caching, cache
+            builder.use Octokit::Response::RaiseError
+            builder.use Faraday::Request::Retry, exceptions: Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Octokit::ServerError]
+            builder.adapter Faraday.default_adapter
+          end
+
+          Octokit.middleware = stack
+
+          github_client = Octokit::Client.new(access_token: TeacherServicesTechDocs::GITHUB_TOKEN)
+          github_client.auto_paginate = true
+          github_client
+        end
+      end
+    end
+  end
+end

--- a/lib/teacher_services_tech_docs/github/dependencies.rb
+++ b/lib/teacher_services_tech_docs/github/dependencies.rb
@@ -1,0 +1,29 @@
+module TeacherServicesTechDocs
+  module GitHub
+    class Dependencies
+      def initialize(lockfile_contents)
+        @parsed_lockfile = Bundler::LockfileParser.new(lockfile_contents)
+      end
+
+      def rails_version
+        @parsed_lockfile.specs.find { |s| s.name == "rails" }.version.to_s
+      end
+
+      def dfe_analytics_version
+        @parsed_lockfile.specs.find { |s| s.name == "dfe-analytics" }&.version&.to_s
+      end
+
+      def dfe_autocomplete_version
+        @parsed_lockfile.specs.find { |s| s.name == "dfe-autocomplete" }&.version&.to_s
+      end
+
+      def dfe_reference_data_version
+        @parsed_lockfile.specs.find { |s| s.name == "dfe-reference-data" }&.version&.to_s
+      end
+
+      def ruby_version
+        Gem::Version.new(@parsed_lockfile.ruby_version.gsub("ruby ", "")).release.to_s
+      end
+    end
+  end
+end

--- a/lib/teacher_services_tech_docs/github/file.rb
+++ b/lib/teacher_services_tech_docs/github/file.rb
@@ -1,0 +1,9 @@
+module TeacherServicesTechDocs
+  module GitHub
+    class File < SimpleDelegator
+      def contents
+        Base64.decode64(content)
+      end
+    end
+  end
+end

--- a/lib/teacher_services_tech_docs/github/markdown_file.rb
+++ b/lib/teacher_services_tech_docs/github/markdown_file.rb
@@ -23,10 +23,10 @@ module TeacherServicesTechDocs
         }
 
         context[:subpage_url] =
-          URI.join(context[:base_url], File.join(".", File.dirname(@path), "/"))
+          URI.join(context[:base_url], ::File.join(".", ::File.dirname(@path), "/"))
 
         context[:image_subpage_url] =
-          URI.join(context[:image_base_url], File.join(".", File.dirname(@path), "/"))
+          URI.join(context[:image_base_url], ::File.join(".", ::File.dirname(@path), "/"))
 
         filters = [
           HTML::Pipeline::MarkdownFilter,

--- a/lib/teacher_services_tech_docs/github/repo.rb
+++ b/lib/teacher_services_tech_docs/github/repo.rb
@@ -57,7 +57,7 @@ module TeacherServicesTechDocs
 
           Octokit.middleware = stack
 
-          github_client = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+          github_client = Octokit::Client.new(access_token: TeacherServicesTechDocs::GITHUB_TOKEN)
           github_client.auto_paginate = true
           github_client
         end

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -42,6 +42,15 @@ Welcome to the technical documentation for apps and libraries in Teacher Service
 | DfE Analytics | [DFE-Digital/dfe-analytics](https://github.com/DFE-Digital/dfe-analytics) | Data Insights |
 | DfE Analytics Dataform | [DFE-Digital/dfe-analytics-dataform](https://github.com/DFE-Digital/dfe-analytics-dataform) | Data Insights |
 
+## Rails apps and dependencies
+
+| repo | rails | ruby | dfe-analytics | dfe-reference-data | dfe-autocomplete |
+| --- | --- | --- | --- | --- | --- | --- |
+<% service_profiles.compact.each do |profile| %>
+| <%= [link_to(profile.name, "https://github.com/#{profile.name}") , profile.rails, profile.ruby, profile.dfe_analytics, profile.dfe_reference_data, profile.dfe_autocomplete].join(' | ') %> |
+<% end %>
+
+
 ## Table of contents
 
 ### Operating a service

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,5 @@ require "webmock/rspec"
 
 require "govuk_tech_docs"
 
+ENV["TECH_DOCS_BUILD_ENV"] = "test"
 require_relative "../lib/teacher_services_tech_docs"


### PR DESCRIPTION
Track Rails and Ruby versions across Teacher Services, and track uptake of our favourite internal libraries. Depends on #37 but could be merged instead.

Add a few services that were missing.

<img width="896" alt="Screenshot 2022-07-01 at 17 07 26" src="https://user-images.githubusercontent.com/642279/176931585-8914e858-6a68-4add-bbe5-8a136163a215.png">

