### PR TITLE
[244] Update domain to tech-docs.teacherservices.cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Teacher Services tech docs
 
-This is the repo for the [Teacher Services tech docs](https://teacher-services-tech-docs.teacherservices.cloud).
+This is the repo for the [Teacher Services tech docs](https://tech-docs.teacherservices.cloud).
 
 ## Developing on this project
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,6 +1,6 @@
 ---
 # Host to use for canonical URL generation (without trailing slash)
-host: teacher-services-tech-docs.teacherservices.cloud
+host: tech-docs.teacherservices.cloud
 
 # Header-related options
 show_govuk_logo: false

--- a/manifests/ingress.yml
+++ b/manifests/ingress.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: teacher-services-tech-docs.teacherservices.cloud
+  - host: tech-docs.teacherservices.cloud
     http:
       paths:
       - pathType: ImplementationSpecific


### PR DESCRIPTION
## What
Update domain to https://tech-docs.teacherservices.cloud to avoid repetition

## How to review
Already deployed: https://tech-docs.teacherservices.cloud 