### PR TITLE
[851] Remove support-for-early-career-teachers

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -102,11 +102,6 @@
   language: 'ruby'
   docsets:
     - path: "documentation"
-- name: "Support for early-career teachers"
-  repo_name: "DFE-Digital/support-for-early-career-teachers"
-  language: 'ruby'
-  docsets:
-    - path: "documentation"
 - name: "National Professional Qualification registration"
   repo_name: "DFE-Digital/npq-registration"
   language: 'ruby'


### PR DESCRIPTION
This is not a rails app anymore and there is no more documentation. Removing to unblock the build.

See failure: https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/6609311429/job/17949267060