### PR TITLE
[937] Use kubelogin in preparation for Azure RBAC

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,17 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Set up kubelogin for non-interactive login
+      uses: azure/use-kubelogin@v1
+      with:
+        kubelogin-version: 'v0.0.34'
+
     - uses: azure/aks-set-context@v3
       with:
         resource-group: s189p01-tsc-pd-rg
         cluster-name: s189p01-tsc-production-aks
+        use-kubelogin: true
+        admin: 'false'
 
     - name: Deploy to AKS
       uses: Azure/k8s-deploy@v4


### PR DESCRIPTION
## Context
AKS cluster will be migrated to Azure RBAC and kubelogin is required

## Guidance to review
- Tested successfully against dev cluster5 *with* Azure RBAC: https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/7725952150/job/21061257014
- Tested successfully against test cluster *without* Azure RBAC: https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/7726249455