### PR TITLE
Update incident playbook to include security and privacy considerations

### DIFF
--- a/source/operating-a-service/how-to-categorise-technical-incidents.html.md
+++ b/source/operating-a-service/how-to-categorise-technical-incidents.html.md
@@ -7,6 +7,7 @@ Ask:
 * What’s the urgency and why?
 * What’s the impact on our users and services?
 * What’s the extent of the issue and what services and users are affected?
+* Are there any security or data privacy implications?
 
 Use the answers to:
 
@@ -19,17 +20,19 @@ The categories are fluid and incidents can increase / decrease in priority follo
 
 ### Description
 
-Highest and most serious level of incident where **two or more** of the following factors apply:
+Highest and most serious level of incident where **one or more** of the following factors apply:
 
 * 60-100% of users affected.
 * Damage to reputation of service is likely to be high.
 * Support staff are mostly or completely unable to resolve tickets due to service being down.
+* Personally identifiable information (PII) or other sensitive data is at risk.
 
 Examples:
 
 * Total outage of ‘Apply for teacher training’ at any time
 * Total outage of ‘Publish postgraduate teacher training courses’ during ‘peak’ time, which is July-October.
 * Primary search filter on ‘Find postgraduate teacher training courses’ going down. This includes location search and subject selection.
+* Users of 'Register trainee teachers' are able to view PII for trainees from other institutions.
 
 ### Stakeholder groups to inform
 
@@ -37,6 +40,7 @@ Team:
 
 * Team
 * Service support staff
+* Architecture team if there are security/privacy implications
 
 Senior stakeholders:
 

--- a/source/operating-a-service/incident-playbook.html.md
+++ b/source/operating-a-service/incident-playbook.html.md
@@ -13,6 +13,12 @@ Self-organise to appoint:
 3. the **Incident support lead**
     (responsible for monitoring Zendesk and alerting the team to any changes in the queues and severity of experience of users).
 
+Notes:
+
+- The comms lead will typically be the delivery manager of the main affected service. If that person is not available, the product manager could take on this role, or a DM from another service.
+- The tech lead will typically be the tech lead of the main affected service, or another developer from the team.
+- The support lead will typically be assigned by the support team.
+
 ### 2. Triage the incident (all incident leads)
 
 The incident leads should [triage the incident](/operating-a-service/how-to-categorise-technical-incidents.html) (P1, P2, P3).
@@ -21,8 +27,8 @@ The incident leads should [triage the incident](/operating-a-service/how-to-cate
 
 After triaging the issue, the tech lead should identify:
 
-- any upstream services which could be contributing to the issue
-- any downstream services likely to be affected by the issue and raise incidents where needed
+- any upstream services (both inside and outside DfE) which could be contributing to the issue
+- any downstream services (both inside and outside DfE) likely to be affected by the issue and raise incidents where needed
 
 ### 4. Create an incident Slack channel and inform the stakeholders (comms lead)
 


### PR DESCRIPTION
This change adds a new question to the incident categorisation guidance, in order to help teams consider whether there are any security or data privacy implications to an incident.

It also provides some more guidance around identifying the tech lead, comms lead and support lead for an incident.