### PR TITLE
Add SNYK scan to build image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,6 @@ name: Deploy to AKS production cluster
 
 on:
   push:
-    branches:
-    - main
   schedule: # 06:00 UTC Mon-Fri
     - cron: '0 6 * * 1-5'
   workflow_dispatch:
@@ -26,32 +24,29 @@ jobs:
 
     - run: bundle exec middleman build
 
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
+    - name: Build and push docker image
+      id: build-image
+      uses: DFE-Digital/github-actions/build-docker-image@master
       with:
-        registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Build Docker Image
-      uses: docker/build-push-action@v3
-      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         context: .
-        tags: |
-          ${{env.DOCKER_IMAGE}}:${{ github.sha }}
-          ${{env.DOCKER_IMAGE}}:latest
-        push: true
+        max-cache: true
+        reuse-cache: true
+        snyk-token: ${{ secrets.SNYK_TOKEN }}
 
     - uses: azure/login@v1
+      if: github.ref == 'refs/heads/main' || github.event_name ==  'schedule'
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
     - name: Set up kubelogin for non-interactive login
       uses: azure/use-kubelogin@v1
+      if: github.ref == 'refs/heads/main' || github.event_name ==  'schedule'
       with:
         kubelogin-version: 'v0.0.34'
 
     - uses: azure/aks-set-context@v3
+      if: github.ref == 'refs/heads/main' || github.event_name ==  'schedule'
       with:
         resource-group: s189p01-tsc-pd-rg
         cluster-name: s189p01-tsc-production-aks
@@ -60,10 +55,11 @@ jobs:
 
     - name: Deploy to AKS
       uses: Azure/k8s-deploy@v4
+      if: github.ref == 'refs/heads/main' || github.event_name ==  'schedule'
       with:
         namespace: bat-production
         manifests: |
-            manifests
+           manifests
         images: ${{env.DOCKER_IMAGE}}:${{ github.sha }}
         annotate-namespace: false
         pull-images: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM nginx:1.23.3
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine3.20
+
+COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY ./build/ /usr/share/nginx/html

--- a/manifests/app.yml
+++ b/manifests/app.yml
@@ -22,7 +22,7 @@ spec:
       - name: teacher-services-tech-docs
         image: ghcr.io/dfe-digital/teacher-services-tech-docs:latest
         ports:
-        - containerPort: 80
+        - containerPort: 8080
         resources:
           requests:
             memory: 64M

--- a/manifests/service.yml
+++ b/manifests/service.yml
@@ -9,4 +9,4 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,45 @@
+
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /tmp/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen       8080;
+        server_name  localhost;
+
+        root /usr/share/nginx/html;
+
+        # Request to / returns 200
+        index  /index.html;
+
+        # Assets are relative to the URL. We capture the prefix and filename
+        # and serve them from the right files
+        location ~ /(stylesheets|assets|javascript)/(.*)$ {
+            alias /usr/share/nginx/html/$1/$2;
+        }
+    }
+}


### PR DESCRIPTION
## Context

We should scan the build image using SNYK

### Changes proposed in this pull request

- Update the deploy workflow to use our build-docker-image github action, 
- Only deploy to production when on main branch or on schedule.  
- and add SNYK key secret so now it does scan and reveals alot of vulnerabililties that need fixing -) 
- fix vulnerabilities by upgrading to latest version of docker image nginxinc/nginx-unprivileged 
- reconfigure to use port 8080 instead of 80. 

### Guidance to review

Check runs
https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/12929968945/job/36060440707

### Link to Trello card

https://trello.com/c/9tIfEgW1/2166-scan-docker-image-in-all-repositories

### Checklist

- [ x] Attach to Trello card
- [x ] Rebased main
- [ x] Cleaned commit history
- [ ] Tested by running locally
