### PR TITLE
Update base image for Dockerfile

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
           file_or_dir: config/*.yml
 
       - name: Set up gem cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginxinc/nginx-unprivileged:1.27.3-alpine3.20
+FROM nginxinc/nginx-unprivileged:1.27.4-alpine3.21
 
 COPY nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
Updating base image to latest 1.27.4 and Gem cache actions to v4

Review:

Failing workflow pre upgrade: - https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/13963004294/job/39087665158
Passing workflow: https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/13989563293

