### PR TITLE
Use `setup/ruby`'s built in caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,22 +16,10 @@ jobs:
         with:
           file_or_dir: config/*.yml
 
-      - name: Set up gem cache
-        uses: actions/cache@v4
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gem-
-
       - name: 'Set up Ruby from .ruby-version'
         uses: ruby/setup-ruby@v1
-
-      - name: 'Install dependencies and set up databases'
-        run: |
-          gem install bundler
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+        with:
+          bundler-cache: true
 
       - name: 'Run tests'
         run: |


### PR DESCRIPTION
Swap to using `setup/ruby`'s built in caching mechanism - this avoids needing to keep up to date with the `actions/cache` action as new versions are released.