### PR TITLE
feat(2326): tech-docs: docker build image -  disable maxcache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         context: .
-        max-cache: true
+        max-cache: false
         reuse-cache: true
         snyk-token: ${{ secrets.SNYK_TOKEN }}
 


### PR DESCRIPTION
###Trello Story ###
https://trello.com/c/ktsJEPED/2326-use-build-docker-image-github-action?filter=member:paulsenior26

### What is in this PR ###
- disabled max-cache (this is a single-stage build)

max-cache enabled:- (1min, 36s)
https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/15584742635/workflow

max-cache disabled:- (1min, 27s)
https://github.com/DFE-Digital/teacher-services-tech-docs/actions/runs/15584804933

